### PR TITLE
Make @execute cmd argument a template string

### DIFF
--- a/lib/subkit-directives.js
+++ b/lib/subkit-directives.js
@@ -88,8 +88,16 @@ const execute = {
     resolve().then(
       result =>
         new Promise((resolve, reject) => {
+          var fieldArgs = {}
+
+          info.fieldNodes[0].arguments.forEach((element) => {
+            fieldArgs[element.name.value] = element.value.values.map((value) =>
+              value.value
+            )
+          })
+
           exec(
-            path.resolve(process.cwd(), args.cmd),
+            path.resolve(process.cwd(), eval("`" + args.cmd + "`")),
             { timeout: args.timeout || 0 },
             (err, stdout, stderr) => {
               if (err) return reject(err);


### PR DESCRIPTION
An example of what I think could be useful to have as a general purpose mechanism for `@directives`. Perhaps it could be worthwhile introducing a custom type to indicate that this string should be interpolated (.e.g. `TemplateString`)

```graphql
project(id: ID): Project
  @execute(cmd: "jq '[.projects | to_entries[] | select(.name == (${fieldArgs.id})]'")
```