### PR TITLE
Add parameters and template string to cmd argument.

### DIFF
--- a/lib/subkit-directives.js
+++ b/lib/subkit-directives.js
@@ -85,28 +85,40 @@ const execute = {
     timeout: { type: GraphQLInt }
   },
   resolve: (resolve, parent, args, ctx, info) =>
-    resolve().then(
-      result =>
-        new Promise((resolve, reject) => {
-          exec(
-            path.resolve(process.cwd(), args.cmd),
-            { timeout: args.timeout || 0 },
-            (err, stdout, stderr) => {
-              if (err) return reject(err);
-              if (stderr) return reject(stderr);
+    resolve().then(result => {
+      const cmdParams = Object.assign(
+        {},
+        result,
+        { parent },
+        { user: ctx.user || {} },
+        { variables: ctx.variables || {} }
+      );
 
-              let data = null;
-              try {
-                data = JSON.parse(stdout);
-              } catch (error) {
-                reject(error);
-              }
-              args.jsonQuery ? jsonQuery(args.jsonQuery, { data }).value : data;
-              resolve(data);
+      return new Promise((resolve, reject) => {
+        exec(
+          `${path.resolve(
+            process.cwd(),
+            format(args.cmd, cmdParams)
+          )} '${JSON.stringify(cmdParams)}'`,
+          { timeout: args.timeout || 0 },
+          (err, stdout, stderr) => {
+            if (err) return reject(err);
+            if (stderr) return reject(stderr);
+
+            let data = null;
+            try {
+              data = JSON.parse(stdout);
+            } catch (error) {
+              reject(error);
             }
-          );
-        })
-    )
+
+            resolve(
+              args.jsonQuery ? jsonQuery(args.jsonQuery, { data }).value : data
+            );
+          }
+        );
+      });
+    })
 };
 
 module.exports = {

--- a/test/directive-execute.test.js
+++ b/test/directive-execute.test.js
@@ -1,0 +1,45 @@
+import { equal, deepEqual } from "assert";
+import { start, stop } from "../lib";
+
+describe("SubKit @execute directive", () => {
+  let url = null;
+
+  before(() => start({}).then(x => (url = x.url)));
+  after(() => stop());
+
+  it("Should execute a script", async () => {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        query: `{
+          items @execute(cmd: "test/fixtures/fetch-items") {
+            id
+          }
+        }`,
+        variables: null,
+        operationName: null
+      })
+    });
+    const actual = await res.json();
+    deepEqual(actual.data.items, [{ id: "A" }, { id: "B" }]);
+  });
+
+  it("Should execute a script and template string args", async () => {
+    const res = await fetch(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        query: `query demo($id: ID!) {
+          item(id: $id) @execute(cmd: "test/fixtures/fetch-item \${variables.id}") {
+            id
+          }
+        }`,
+        variables: { id: "A" },
+        operationName: "demo"
+      })
+    });
+    const actual = await res.json();
+    deepEqual(actual.data.item, { id: "A" });
+  });
+});

--- a/test/fixtures/fetch-item
+++ b/test/fixtures/fetch-item
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+const input = JSON.parse(process.argv[process.argv.length - 1]);
+console.log(JSON.stringify(input.variables));

--- a/test/fixtures/fetch-items
+++ b/test/fixtures/fetch-items
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+console.log(JSON.stringify([{id: 'A'}, {id: 'B'}]))


### PR DESCRIPTION
* Argument object {resolverResult, parent, user, variables}
* `@execute(cmd: "test/fixtures/fetch-item \${variables.id}")`
* Example and [Integration-Test](https://github.com/CodeCommission/subkit/compare/EXECUTE_DIRECTIVE?expand=1#diff-3ad1f0edb4a7cf1223f2e3ad1e597c60R28)