### PR TITLE
Make `args` available in `cmdParams`

### DIFF
--- a/lib/subkit-directives.js
+++ b/lib/subkit-directives.js
@@ -71,23 +71,11 @@ const execute = {
   },
   resolve: (resolve, parent, args, ctx, info) =>
     resolve().then(result => {
-      const fieldArgs = {};
-      info.fieldNodes[0].arguments.forEach(element => {
-        if (element.value && element.value.value) {
-          fieldArgs[element.name.value] = element.value.value;
-        }
-        if (element.value && element.value.values) {
-          fieldArgs[element.name.value] = element.value.values.map(
-            value => value.value
-          );
-        }
-      });
-
       const cmdParams = Object.assign(
         {},
         result,
         { parent },
-        { args: fieldArgs },
+        { args: args },
         { user: ctx.user || {} },
         { variables: ctx.variables || {} }
       );


### PR DESCRIPTION
Makes this work again:

```graphql
apps(filter: [String]): [App]
  @execute(cmd: "echo '${args.filter}", timeout: 1000)```
```
Not sure how to add tests for this. Suggestions?
