### PR TITLE
Provide field args to directive resolver

### DIFF
--- a/lib/custom-directives.js
+++ b/lib/custom-directives.js
@@ -19,7 +19,7 @@ function defaultResolveFn(source, args, context, info) {
   }
 }
 
-function resolveWithDirective(resolve, source, directive, context, info) {
+function resolveWithDirective(resolve, source, directive, fieldArgs, context, info) {
   const directiveConfig = info.schema._directives.filter(
     d => directive.name.value === d.name
   )[0];
@@ -29,7 +29,7 @@ function resolveWithDirective(resolve, source, directive, context, info) {
     args[arg.name.value] =
       arg.value.value || GraphQLJSON.parseLiteral(arg.value);
   }
-  args = Object.assign({}, args, context.variables);
+  args = Object.assign({}, args, fieldArgs);
   return (
     directiveConfig &&
     directiveConfig.resolve &&
@@ -56,6 +56,7 @@ function resolverMiddlewareWrapper(
       () => Promise.resolve(resolve(source, args, context, info)),
       source,
       directive,
+      args,
       context,
       info
     );
@@ -68,6 +69,7 @@ function resolverMiddlewareWrapper(
           () => Promise.resolve(result),
           source,
           directiveNext,
+          args,
           context,
           info
         )

--- a/lib/subkit-directives.js
+++ b/lib/subkit-directives.js
@@ -71,23 +71,11 @@ const execute = {
   },
   resolve: (resolve, parent, args, ctx, info) =>
     resolve().then(result => {
-      const fieldArgs = {};
-      info.fieldNodes[0].arguments.forEach(element => {
-        if (element.value && element.value.value) {
-          fieldArgs[element.name.value] = element.value.value;
-        }
-        if (element.value && element.value.values) {
-          fieldArgs[element.name.value] = element.value.values.map(
-            value => value.value
-          );
-        }
-      });
-
       const cmdParams = Object.assign(
         {},
         result,
         { parent },
-        { args: fieldArgs },
+        { args: args },
         { user: ctx.user || {} },
         { variables: ctx.variables || {} }
       );


### PR DESCRIPTION
This replaces global variables in favour of field args. This limits the availability of variables to the ones which actually is expected on  that node. 