### PR TITLE
Treat every String directive argument as template string

### DIFF
--- a/lib/custom-directives.js
+++ b/lib/custom-directives.js
@@ -23,13 +23,29 @@ function resolveWithDirective(resolve, source, directive, fieldArgs, context, in
   const directiveConfig = info.schema._directives.filter(
     d => directive.name.value === d.name
   )[0];
-
   let args = {};
+
+  const cmdParams = Object.assign(
+    {},
+    { parent: source },
+    { args: fieldArgs },
+    { user: context.user || {} },
+    { variables: context.variables || {} }
+  );
+
   for (const arg of directive.arguments) {
-    args[arg.name.value] =
-      arg.value.value || GraphQLJSON.parseLiteral(arg.value);
+    let value = '';
+
+    if (arg.value.kind === 'StringValue') {
+      value = format(arg.value.value, cmdParams)
+    } else {
+      value = arg.value.value || GraphQLJSON.parseLiteral(arg.value);
+    }
+    args[arg.name.value] = value
   }
+
   args = Object.assign({}, args, fieldArgs);
+
   return (
     directiveConfig &&
     directiveConfig.resolve &&

--- a/lib/subkit-directives.js
+++ b/lib/subkit-directives.js
@@ -71,18 +71,9 @@ const execute = {
   },
   resolve: (resolve, parent, args, ctx, info) =>
     resolve().then(result => {
-      const cmdParams = Object.assign(
-        {},
-        result,
-        { parent },
-        { args: args },
-        { user: ctx.user || {} },
-        { variables: ctx.variables || {} }
-      );
-
       return new Promise((resolve, reject) => {
         exec(
-          `${path.resolve(process.cwd(), format(args.cmd, cmdParams))}`,
+          `${path.resolve(process.cwd(), args.cmd)}`,
           { timeout: args.timeout || 0 },
           (err, stdout, stderr) => {
             if (err) return reject(err);


### PR DESCRIPTION
Might be worthwhile limiting to a special type, e.g. `TemplateString` - But does the job for now. 

