### PR TITLE
Execute with bash and in current directory

### DIFF
--- a/lib/subkit-directives.js
+++ b/lib/subkit-directives.js
@@ -73,8 +73,12 @@ const execute = {
     resolve().then(result => {
       return new Promise((resolve, reject) => {
         exec(
-          `${path.resolve(process.cwd(), args.cmd)}`,
-          {timeout: args.timeout || 0},
+          args.cmd,
+          {
+            timeout: args.timeout || 0,
+            shell: '/bin/bash',
+            cwd: process.cwd()
+          },
           (err, stdout, stderr) => {
             if (err) return reject(err);
             if (stderr) return reject(stderr);


### PR DESCRIPTION
- Allows using `ssh` or `jq` from path
- Full bash, for advanced scripting
- Relative to current process directory